### PR TITLE
Simplified Run Logic

### DIFF
--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -32,8 +32,6 @@ func TestTerminalDimensionsCanBeChanged(t *testing.T) {
 		return true
 	}))
 
-	serverOpts = append(serverOpts)
-
 	terminalServer, err := server.New(serverOpts...)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -32,8 +32,7 @@ func TestTerminalDimensionsCanBeChanged(t *testing.T) {
 		return true
 	}))
 
-	// Disable gRPC-Web wrapping so that we can use a normal gRPC client that talks over HTTP/2 for this test
-	serverOpts = append(serverOpts, server.WithGuestUsesNoGRPCWebWrapping())
+	serverOpts = append(serverOpts)
 
 	terminalServer, err := server.New(serverOpts...)
 	if err != nil {

--- a/internal/server/option.go
+++ b/internal/server/option.go
@@ -22,12 +22,6 @@ func WithServerAddress(address string) Option {
 	}
 }
 
-func WithGuestUsesNoGRPCWebWrapping() Option {
-	return func(ts *TerminalServer) {
-		ts.guestUsesNoGRPCWebWrapping = true
-	}
-}
-
 func WithWebsocketOriginFunc(websocketOriginFunc WebsocketOriginFunc) Option {
 	return func(ts *TerminalServer) {
 		ts.websocketOriginFunc = websocketOriginFunc

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,63 +84,53 @@ func (ts *TerminalServer) Run(ctx context.Context) (err error) {
 	mux := cmux.New(ts.listener)
 	defer mux.Close()
 
-	// gRPC server that deals with Hosts
-	hostServer := grpc.NewServer()
-	defer hostServer.GracefulStop()
-	api.RegisterHostServiceServer(hostServer, ts)
+	grpcServer := grpc.NewServer()
+	defer grpcServer.GracefulStop()
+	api.RegisterHostServiceServer(grpcServer, ts)
+	api.RegisterGuestServiceServer(grpcServer, ts)
 
-	// nolint:nestif // moving these into separate functions would make the whole thing even more complicated
-	if ts.guestUsesNoGRPCWebWrapping {
-		api.RegisterGuestServiceServer(hostServer, ts)
-	} else {
-		guestListener := mux.Match(
-			cmux.HTTP1HeaderField("content-type", "application/grpc-web+proto"),
-			cmux.HTTP1HeaderField("content-type", "application/grpc-web+proto"),
-			cmux.HTTP1HeaderField("content-type", "application/grpc-web-text"),
-			cmux.HTTP1HeaderField("content-type", "application/grpc-web-text"),
-			cmux.HTTP1HeaderField("Sec-WebSocket-Protocol", "grpc-websockets"),
-		)
-		// gRPC-Web server that deals with Guests
-		guestServer := grpc.NewServer()
-		api.RegisterGuestServiceServer(guestServer, ts)
-		// Since we use gRPC-Web with Websockets transport, we need additional wrapping
-		wrappedGuestServer := grpcweb.WrapServer(
-			guestServer,
+	// Since we use gRPC-Web with Websockets transport, we need additional wrapping
+	webSocketServer := http.Server{
+		Handler: grpcweb.WrapServer(
+			grpcServer,
 			grpcweb.WithWebsockets(true),
 			grpcweb.WithWebsocketOriginFunc(ts.websocketOriginFunc),
-		)
-
-		guestHTTPServer := http.Server{
-			Handler: wrappedGuestServer,
-		}
-
-		go func() {
-			defer cancel()
-
-			ts.logger.Infof("starting GuestService gRPC-Web server at %s", guestListener.Addr().String())
-
-			if err := guestHTTPServer.Serve(guestListener); err != nil {
-				if !errors.Is(err, http.ErrServerClosed) {
-					ts.logger.Warnf("GuestService gRPC-Web server failed: %v", err)
-				}
-			}
-		}()
-
-		defer func() {
-			if localErr := guestHTTPServer.Shutdown(context.Background()); localErr != nil {
-				err = localErr
-			}
-		}()
+		),
 	}
+	defer func() {
+		if localErr := webSocketServer.Shutdown(context.Background()); localErr != nil {
+			err = localErr
+		}
+	}()
 
-	hostListener := mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
+	webSocketListener := mux.Match(
+		cmux.HTTP1HeaderField("content-type", "application/grpc-web+proto"),
+		cmux.HTTP1HeaderField("content-type", "application/grpc-web+proto"),
+		cmux.HTTP1HeaderField("content-type", "application/grpc-web-text"),
+		cmux.HTTP1HeaderField("content-type", "application/grpc-web-text"),
+		cmux.HTTP1HeaderField("Sec-WebSocket-Protocol", "grpc-websockets"),
+	)
 
 	go func() {
 		defer cancel()
 
-		ts.logger.Infof("starting HostService gRPC server at %s", hostListener.Addr().String())
+		ts.logger.Infof("starting GuestService gRPC-Web server at %s", webSocketListener.Addr().String())
 
-		if err := hostServer.Serve(hostListener); err != nil {
+		if err := webSocketServer.Serve(webSocketListener); err != nil {
+			if !errors.Is(err, http.ErrServerClosed) {
+				ts.logger.Warnf("GuestService gRPC-Web server failed: %v", err)
+			}
+		}
+	}()
+
+	grpcListener := mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
+
+	go func() {
+		defer cancel()
+
+		ts.logger.Infof("starting HostService gRPC server at %s", grpcListener.Addr().String())
+
+		if err := grpcServer.Serve(grpcListener); err != nil {
 			if !errors.Is(err, grpc.ErrServerStopped) {
 				ts.logger.Warnf("HostService gRPC server failed: %v", err)
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,8 +28,6 @@ type TerminalServer struct {
 	address  string
 	listener net.Listener
 
-	guestUsesNoGRPCWebWrapping bool
-
 	api.UnimplementedGuestServiceServer
 	api.UnimplementedHostServiceServer
 


### PR DESCRIPTION
By always serving both Host and Guest services over gRPC and gRPC-web.