### PR TITLE
terminal serve: TLS support

### DIFF
--- a/internal/server/option.go
+++ b/internal/server/option.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crypto/tls"
 	"github.com/sirupsen/logrus"
 	"net/http"
 )
@@ -31,5 +32,11 @@ func WithWebsocketOriginFunc(websocketOriginFunc WebsocketOriginFunc) Option {
 func WithLocatorGenerator(locatorGenerator LocatorGenerator) Option {
 	return func(ts *TerminalServer) {
 		ts.generateLocator = locatorGenerator
+	}
+}
+
+func WithTLSConfig(tlsConfig *tls.Config) Option {
+	return func(ts *TerminalServer) {
+		ts.tlsConfig = tlsConfig
 	}
 }


### PR DESCRIPTION
Also supports in-memory certificate and key generation with `--tls-ephemeral`, useful for [GFE ↔︎ Google Cloud backend](https://cloud.google.com/load-balancing/docs/ssl-certificates/encryption-to-the-backends) scenarios that don't require a valid certificate.