### PR TITLE
Don't check WebSocket's Origin header

### DIFF
--- a/internal/command/serve.go
+++ b/internal/command/serve.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"math/big"
-	"net/http"
 	"os"
 	"strings"
 )
@@ -20,7 +19,6 @@ var logLevel string
 var serverAddress string
 var tlsEphemeral bool
 var tlsCertFile, tlsKeyFile string
-var allowedOrigins []string
 
 func runServe(cmd *cobra.Command, args []string) error {
 	logLevel, err := logrus.ParseLevel(logLevel)
@@ -68,20 +66,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	websocketOriginFunc := func(request *http.Request) bool {
-		for _, allowedOrigin := range allowedOrigins {
-			if request.Header.Get("Origin") == allowedOrigin {
-				return true
-			}
-		}
-
-		return false
-	}
-
 	terminalServer, err := server.New(
 		server.WithLogger(logger),
 		server.WithServerAddress(serverAddress),
-		server.WithWebsocketOriginFunc(websocketOriginFunc),
 		server.WithTLSConfig(tlsConfig),
 	)
 	if err != nil {
@@ -119,9 +106,6 @@ func newServeCmd() *cobra.Command {
 		"enable TLS and use the specified certificate file (must also specify --tls-key-file)")
 	cmd.PersistentFlags().StringVar(&tlsKeyFile, "tls-key-file", "",
 		"enable TLS and use the specified key file (must also specify --tls-cert-file)")
-
-	cmd.PersistentFlags().StringSliceVar(&allowedOrigins, "allowed-origins", []string{},
-		"a list comma-separated origins that are allowed to talk with the guest's gRPC-Web WebSocket server")
 
 	return cmd
 }

--- a/internal/server/option.go
+++ b/internal/server/option.go
@@ -3,12 +3,10 @@ package server
 import (
 	"crypto/tls"
 	"github.com/sirupsen/logrus"
-	"net/http"
 )
 
 type Option func(*TerminalServer)
 
-type WebsocketOriginFunc func(*http.Request) bool
 type LocatorGenerator func() string
 
 func WithLogger(logger *logrus.Logger) Option {
@@ -20,12 +18,6 @@ func WithLogger(logger *logrus.Logger) Option {
 func WithServerAddress(address string) Option {
 	return func(ts *TerminalServer) {
 		ts.address = address
-	}
-}
-
-func WithWebsocketOriginFunc(websocketOriginFunc WebsocketOriginFunc) Option {
-	return func(ts *TerminalServer) {
-		ts.websocketOriginFunc = websocketOriginFunc
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,8 +35,7 @@ type TerminalServer struct {
 	api.UnimplementedGuestServiceServer
 	api.UnimplementedHostServiceServer
 
-	websocketOriginFunc WebsocketOriginFunc
-	generateLocator     LocatorGenerator
+	generateLocator LocatorGenerator
 }
 
 func New(opts ...Option) (*TerminalServer, error) {
@@ -53,11 +52,6 @@ func New(opts ...Option) (*TerminalServer, error) {
 	if ts.logger == nil {
 		ts.logger = logrus.New()
 		ts.logger.Out = io.Discard
-	}
-	if ts.websocketOriginFunc == nil {
-		ts.websocketOriginFunc = func(*http.Request) bool {
-			return false
-		}
 	}
 	if ts.generateLocator == nil {
 		ts.generateLocator = func() string {
@@ -91,7 +85,9 @@ func (ts *TerminalServer) Run(ctx context.Context) (err error) {
 	grpcWebServer := grpcweb.WrapServer(
 		grpcServer,
 		grpcweb.WithWebsockets(true),
-		grpcweb.WithWebsocketOriginFunc(ts.websocketOriginFunc),
+		grpcweb.WithWebsocketOriginFunc(func(request *http.Request) bool {
+			return true
+		}),
 	)
 
 	go func() {


### PR DESCRIPTION
We're already running our own RPC server with authentication over that WebSocket, so it gives little to no security benefit, yet hinders testing and usage beyond Cirrus CI.

See https://devcenter.heroku.com/articles/websocket-security#origin-header.