### PR TITLE
A proper gRPC-Web over WebSocket header check for HTTP/2

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -97,7 +97,7 @@ func (ts *TerminalServer) Run(ctx context.Context) (err error) {
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				contentType := r.Header.Get("content-type")
 				switch {
-				case grpcWebServer.IsGrpcWebSocketRequest(r):
+				case strings.ToLower(r.Header.Get("Sec-Websocket-Protocol")) == "grpc-websockets":
 					grpcWebServer.ServeHTTP(w, r)
 				case strings.HasPrefix(contentType, "application/grpc-web"):
 					grpcWebServer.ServeHTTP(w, r)


### PR DESCRIPTION
There's no `Connection: Upgrade` when using HTTP/2, so gRPC-Web over WebSocket fails to choose the appropriate handler.