### PR TITLE
Allow multiple addresses to listen to

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cirruslabs/cirrus-ci-agent v1.51.0
 	github.com/creack/pty v1.1.13
 	github.com/google/uuid v1.2.0
-	github.com/gorilla/websocket v1.4.2
+	github.com/gorilla/handlers v1.5.1
 	github.com/improbable-eng/grpc-web v0.14.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -145,6 +147,8 @@ github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/internal/command/serve.go
+++ b/internal/command/serve.go
@@ -16,7 +16,7 @@ import (
 )
 
 var logLevel string
-var serverAddress string
+var serverAddresses []string
 var tlsEphemeral bool
 var tlsCertFile, tlsKeyFile string
 
@@ -27,6 +27,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	logger := logrus.New()
 	logger.SetLevel(logLevel)
+	logger.SetFormatter(&logrus.TextFormatter{
+		DisableTimestamp: true,
+	})
 
 	var tlsConfig *tls.Config
 
@@ -68,7 +71,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	terminalServer, err := server.New(
 		server.WithLogger(logger),
-		server.WithServerAddress(serverAddress),
+		server.WithAddresses(serverAddresses),
 		server.WithTLSConfig(tlsConfig),
 	)
 	if err != nil {
@@ -97,8 +100,8 @@ func newServeCmd() *cobra.Command {
 		port = "8080"
 	}
 
-	cmd.PersistentFlags().StringVarP(&serverAddress, "listen", "l", fmt.Sprintf(":%s", port),
-		"address to listen on")
+	cmd.PersistentFlags().StringSliceVarP(&serverAddresses, "listen", "l", []string{fmt.Sprintf(":%s", port)},
+		"addresses to listen on")
 
 	cmd.PersistentFlags().BoolVar(&tlsEphemeral, "tls-ephemeral", false,
 		"enable TLS and generate a self-signed and ephemeral certificate and key")

--- a/internal/command/serve.go
+++ b/internal/command/serve.go
@@ -95,7 +95,7 @@ func newServeCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", "info",
 		fmt.Sprintf("logging level (possible levels: %s)", strings.Join(logLevelNames, ", ")))
 
-	//nolint:ifshort
+	// nolint:ifshort // false-positive similar to https://github.com/esimonov/ifshort/issues/12
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"

--- a/internal/command/serve.go
+++ b/internal/command/serve.go
@@ -95,6 +95,7 @@ func newServeCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", "info",
 		fmt.Sprintf("logging level (possible levels: %s)", strings.Join(logLevelNames, ", ")))
 
+	//nolint:ifshort
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestTerminalDimensionsCanBeChanged(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	serverAddress := "localhost:11111"
+	serverAddress := ":11111"
 
 	// Initialize terminal server
 	var serverOpts []server.Option

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestTerminalDimensionsCanBeChanged(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
+	serverAddress := "localhost:11111"
 
 	// Initialize terminal server
 	var serverOpts []server.Option
@@ -24,6 +25,7 @@ func TestTerminalDimensionsCanBeChanged(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.TraceLevel)
 	serverOpts = append(serverOpts, server.WithLogger(logger))
+	serverOpts = append(serverOpts, server.WithAddresses([]string{serverAddress}))
 
 	terminalServer, err := server.New(serverOpts...)
 	if err != nil {
@@ -40,7 +42,7 @@ func TestTerminalDimensionsCanBeChanged(t *testing.T) {
 	// Initialize terminal host
 	hostOpts := []host.Option{
 		host.WithLogger(logger),
-		host.WithServerAddress("http://" + terminalServer.ServerAddress()),
+		host.WithServerAddress("http://" + serverAddress),
 	}
 
 	const secret = "fixed secret used in tests"
@@ -72,7 +74,7 @@ func TestTerminalDimensionsCanBeChanged(t *testing.T) {
 	}
 
 	// Emulate guest: open up a terminal channel, just like a web UI would do
-	clientConn, err := grpc.Dial(terminalServer.ServerAddress(), grpc.WithInsecure())
+	clientConn, err := grpc.Dial(serverAddress, grpc.WithInsecure())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/server/option.go
+++ b/internal/server/option.go
@@ -15,9 +15,9 @@ func WithLogger(logger *logrus.Logger) Option {
 	}
 }
 
-func WithServerAddress(address string) Option {
+func WithAddresses(addresses []string) Option {
 	return func(ts *TerminalServer) {
-		ts.address = address
+		ts.addresses = addresses
 	}
 }
 

--- a/internal/server/rpc_guest.go
+++ b/internal/server/rpc_guest.go
@@ -19,6 +19,8 @@ func (ts *TerminalServer) TerminalChannel(channel api.GuestService_TerminalChann
 		return status.Errorf(codes.FailedPrecondition, "expected a Hello message")
 	}
 
+	ts.logger.Infof("Got hello from %s", helloFromGuest.Locator)
+
 	// Find a terminal with the requested locator
 	terminal := ts.findTerminal(helloFromGuest.Locator)
 	if terminal == nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cirruslabs/terminal/internal/api"
 	"github.com/cirruslabs/terminal/internal/server/terminal"
 	"github.com/google/uuid"
+	"github.com/gorilla/handlers"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/http2"
@@ -28,8 +29,7 @@ type TerminalServer struct {
 	terminalsLock sync.RWMutex
 	terminals     map[string]*terminal.Terminal
 
-	address   string
-	listener  net.Listener
+	addresses []string
 	tlsConfig *tls.Config
 
 	api.UnimplementedGuestServiceServer
@@ -58,15 +58,8 @@ func New(opts ...Option) (*TerminalServer, error) {
 			return uuid.New().String()
 		}
 	}
-	if ts.address == "" {
-		ts.address = "0.0.0.0:0"
-	}
-
-	var err error
-
-	ts.listener, err = net.Listen("tcp", ts.address)
-	if err != nil {
-		return nil, err
+	if len(ts.addresses) == 0 {
+		ts.addresses = []string{"0.0.0.0:0"}
 	}
 
 	return ts, nil
@@ -90,48 +83,66 @@ func (ts *TerminalServer) Run(ctx context.Context) (err error) {
 		}),
 	)
 
-	go func() {
-		defer cancel()
+	commonHandler := handlers.CustomLoggingHandler(ts.logger.Writer(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contentType := r.Header.Get("content-type")
+		switch {
+		case strings.ToLower(r.Header.Get("Sec-Websocket-Protocol")) == "grpc-websockets":
+			grpcWebServer.ServeHTTP(w, r)
+		case strings.HasPrefix(contentType, "application/grpc-web"):
+			grpcWebServer.ServeHTTP(w, r)
+		case strings.HasPrefix(contentType, "application/grpc"):
+			grpcServer.ServeHTTP(w, r)
+		default:
+			fmt.Fprint(w, "Please use gRPC over HTTP/2 or gRPC-web over HTTP/1")
+		}
+	}), func(w io.Writer, p handlers.LogFormatterParams) {
+		req := p.Request
+
+		uri := req.RequestURI
+		if uri == "" {
+			uri = p.URL.RequestURI()
+		}
+
+		_, _ = fmt.Fprintln(w, req.Method, uri, req.Proto, p.StatusCode, p.Size)
+	})
+
+	startServer := func(address string) error {
+		listener, err := net.Listen("tcp", address)
+		if err != nil {
+			return err
+		}
 
 		server := http.Server{
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				contentType := r.Header.Get("content-type")
-				switch {
-				case strings.ToLower(r.Header.Get("Sec-Websocket-Protocol")) == "grpc-websockets":
-					grpcWebServer.ServeHTTP(w, r)
-				case strings.HasPrefix(contentType, "application/grpc-web"):
-					grpcWebServer.ServeHTTP(w, r)
-				case strings.HasPrefix(contentType, "application/grpc"):
-					grpcServer.ServeHTTP(w, r)
-				default:
-					fmt.Fprint(w, "Please use gRPC over HTTP/2 or gRPC-web over HTTP/1")
-				}
-			}),
+			Handler:   commonHandler,
 			TLSConfig: ts.tlsConfig,
 		}
 
-		var serveErr error
+		ts.logger.Infof("Starting server on %s...", listener.Addr().String())
+
 		if server.TLSConfig != nil {
-			serveErr = server.ServeTLS(ts.listener, "", "")
+			return server.ServeTLS(listener, "", "")
 		} else {
 			// enable HTTP/2 without TLS aka h2c
 			h2s := &http2.Server{}
 			server.Handler = h2c.NewHandler(server.Handler, h2s)
-			serveErr = server.Serve(ts.listener)
+			return server.Serve(listener)
 		}
+	}
 
-		if serveErr != nil {
-			ts.logger.Warnf("mux server failed: %v", err)
-		}
-	}()
+	for _, address := range ts.addresses {
+		address := address
+		go func() {
+			defer cancel()
+
+			if serverErr := startServer(address); serverErr != nil {
+				ts.logger.Warnf("server failed to start on %s: %v", address, err)
+			}
+		}()
+	}
 
 	<-subCtx.Done()
 
 	return nil
-}
-
-func (ts *TerminalServer) ServerAddress() string {
-	return ts.listener.Addr().String()
 }
 
 func (ts *TerminalServer) registerTerminal(terminal *terminal.Terminal) error {


### PR DESCRIPTION
That makes life easier to expose gRPC over HTTP/2 and gRPC-web over HTTP/1.1 on GKE via an ingress.

There is basically `terminal-deployment` with:

```yaml
ports:
    - containerPort: 8443
      name: grpc
      protocol: TCP
    - containerPort: 8080
      name: ws
      protocol: TCP
readinessProbe:
    httpGet:
      path: /healthz
      port: grpc
      scheme: HTTPS
```

And a `terminal-service` with:


```yaml
metadata:
  annotations:
    cloud.google.com/app-protocols: '{"grpc": "HTTP2", "ws": "HTTPS"}'
    cloud.google.com/backend-config: '{"default": "terminal-backendconfig"}'
spec:
  clusterIP: 10.27.244.101
  externalTrafficPolicy: Cluster
  ports:
  - name: grpc
    port: 8443
    protocol: TCP
  - name: ws
    port: 8080
    protocol: TCP
```

And finally an ingress which defaults to `grpc` but uses `ws` for `/GuestService/*` path:

```yaml
spec:
  backend:
    serviceName: cirrus-terminal
    servicePort: grpc
  rules:
  - host: terminal.cirrus-ci.com
    http:
      paths:
      - backend:
          serviceName: cirrus-terminal
          servicePort: ws
        path: /GuestService/*
```