### PR TITLE
Shell PTY: passthrough environment variables

### DIFF
--- a/pkg/host/common.go
+++ b/pkg/host/common.go
@@ -10,6 +10,8 @@ import (
 type TerminalHost struct {
 	logger *zap.Logger
 
+	shellEnv []string
+
 	serverAddress string
 
 	trustedSecret string

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -118,7 +118,7 @@ func (th *TerminalHost) Run(ctx context.Context) error {
 			return fmt.Errorf("%w: should've received a DataChannelRequest message", ErrProtocol)
 		}
 
-		session := session.New(th.logger, dataChannelRequest.Token)
+		session := session.New(th.logger, dataChannelRequest.Token, th.shellEnv)
 		sessionWG.Add(1)
 
 		go func() {

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -18,10 +18,10 @@ func TestNumSessionsNormalAndFunc(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	session1 := session.New(zap.NewNop(), "first one")
+	session1 := session.New(zap.NewNop(), "first one", nil)
 	terminalHost.registerSession(session1)
 
-	session2 := session.New(zap.NewNop(), "second one")
+	session2 := session.New(zap.NewNop(), "second one", nil)
 	terminalHost.registerSession(session2)
 
 	assert.Equal(t, 2, terminalHost.NumSessions())

--- a/pkg/host/option.go
+++ b/pkg/host/option.go
@@ -31,3 +31,9 @@ func WithLocatorCallback(locatorCallback LocatorCallback) Option {
 		th.locatorCallback = locatorCallback
 	}
 }
+
+func WithShellEnv(shellEnv []string) Option {
+	return func(th *TerminalHost) {
+		th.shellEnv = shellEnv
+	}
+}

--- a/pkg/host/session/session.go
+++ b/pkg/host/session/session.go
@@ -26,14 +26,17 @@ type Session struct {
 
 	token string
 
+	shellEnv []string
+
 	lastActivityLock sync.Mutex
 	lastActivity     time.Time
 }
 
-func New(logger *zap.Logger, token string) *Session {
+func New(logger *zap.Logger, token string, shellEnv []string) *Session {
 	return &Session{
-		logger: logger.Sugar(),
-		token:  token,
+		logger:   logger.Sugar(),
+		token:    token,
+		shellEnv: shellEnv,
 	}
 }
 
@@ -68,7 +71,7 @@ func (session *Session) Run(
 		return
 	}
 
-	shellPty, err := NewShellPTY(session.logger, dimensions)
+	shellPty, err := NewShellPTY(session.logger, dimensions, session.shellEnv)
 	if err != nil {
 		session.logger.Warnf("failed to create PTY with shell: %v", err)
 		return

--- a/pkg/host/session/session_test.go
+++ b/pkg/host/session/session_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestLastActivitySimple(t *testing.T) {
-	session := New(zap.NewNop(), "")
+	session := New(zap.NewNop(), "", nil)
 
 	require.Equal(t, time.Time{}, session.LastActivity())
 

--- a/pkg/host/session/shellpty.go
+++ b/pkg/host/session/shellpty.go
@@ -14,13 +14,17 @@ type ShellPTY struct {
 	pty      *os.File
 }
 
-func NewShellPTY(logger *zap.SugaredLogger, dimensions *api.TerminalDimensions) (*ShellPTY, error) {
+func NewShellPTY(logger *zap.SugaredLogger, dimensions *api.TerminalDimensions, env []string) (*ShellPTY, error) {
 	// Create a PTY with a shell attached to it
 	shellPath := determineShellPath()
 	shellCmd := exec.Command(shellPath)
 
 	// Inherit this process environment variables
-	shellCmd.Env = os.Environ()
+	if len(env) == 0 {
+		shellCmd.Env = os.Environ()
+	} else {
+		shellCmd.Env = env
+	}
 
 	// Set TERM to avoid "Error opening terminal: unknown." error
 	shellCmd.Env = append(shellCmd.Env, "TERM=xterm")

--- a/pkg/host/session/shellpty_test.go
+++ b/pkg/host/session/shellpty_test.go
@@ -16,7 +16,28 @@ func TestEnvPassthrough(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	shellPty, err := session.NewShellPTY(zap.NewNop().Sugar(), nil)
+	shellPty, err := session.NewShellPTY(zap.NewNop().Sugar(), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := fmt.Fprintln(shellPty, "env ; exit"); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := bytes.NewBuffer([]byte{})
+
+	_, _ = io.Copy(buf, shellPty)
+
+	if err := shellPty.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Contains(t, buf.String(), "TEST_ENV_PASSTHROUGH_CANARY=some value")
+}
+
+func TestEnvCustom(t *testing.T) {
+	shellPty, err := session.NewShellPTY(zap.NewNop().Sugar(), nil, []string{"TEST_ENV_PASSTHROUGH_CANARY=some value"})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
To avoid unexported variables like `PATH`.

Was noticed in https://github.com/cirruslabs/cirrus-ci-docs/issues/929#issuecomment-953371833.