### PR TITLE
Terminal host: introduce LastConnection() method

### DIFF
--- a/internal/command/serve.go
+++ b/internal/command/serve.go
@@ -46,9 +46,6 @@ func runServe(cmd *cobra.Command, args []string) (err error) {
 		logger, err = zapdriver.NewProduction()
 	}
 
-	if err != nil {
-		return err
-	}
 	defer func() {
 		_ = logger.Sync()
 	}()

--- a/pkg/host/common.go
+++ b/pkg/host/common.go
@@ -18,6 +18,9 @@ type TerminalHost struct {
 
 	locatorCallback LocatorCallback
 
+	lastConnectionMtx sync.Mutex
+	lastConnection    time.Time
+
 	sessionsLock     sync.Mutex
 	sessions         map[string]*session.Session
 	lastRegistration time.Time

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -94,6 +94,10 @@ func (th *TerminalHost) Run(ctx context.Context) error {
 		}
 	}
 
+	th.lastConnectionMtx.Lock()
+	th.lastConnection = time.Now()
+	th.lastConnectionMtx.Unlock()
+
 	var sessionWG sync.WaitGroup
 	defer sessionWG.Wait()
 
@@ -128,6 +132,13 @@ func (th *TerminalHost) Run(ctx context.Context) error {
 			sessionWG.Done()
 		}()
 	}
+}
+
+func (th *TerminalHost) LastConnection() time.Time {
+	th.sessionsLock.Lock()
+	defer th.sessionsLock.Unlock()
+
+	return th.lastConnection
 }
 
 func (th *TerminalHost) LastRegistration() time.Time {

--- a/pkg/host/host_windows.go
+++ b/pkg/host/host_windows.go
@@ -17,6 +17,10 @@ func (th *TerminalHost) Run(ctx context.Context) error {
 	return ErrUnsupported
 }
 
+func (th *TerminalHost) LastConnection() time.Time {
+	return time.Time{}
+}
+
 func (th *TerminalHost) LastRegistration() time.Time {
 	return time.Time{}
 }


### PR DESCRIPTION
The agent will use this method instead of `LastRegistration` in https://github.com/cirruslabs/cirrus-ci-agent/pull/194 to make the testing easier.