### PR TITLE
Server: enable gRPC-Web websocket keepalive ping

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -98,6 +98,7 @@ func (ts *TerminalServer) Run(ctx context.Context) (err error) {
 		grpcweb.WithWebsocketOriginFunc(func(request *http.Request) bool {
 			return true
 		}),
+		grpcweb.WithWebsocketPingInterval(keepaliveInterval),
 	)
 
 	grpcHandler := func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,7 +23,7 @@ import (
 
 var ErrNewTerminalRefused = errors.New("refusing to register new terminal")
 
-const keepaliveInterval = 5 * time.Minute
+const keepaliveInterval = 1 * time.Minute
 
 type TerminalServer struct {
 	logger *zap.Logger


### PR DESCRIPTION
Turns out that only gRPC server keep-alives were enabled, but not gRPC-Web ones (https://github.com/improbable-eng/grpc-web/pull/546).

See https://github.com/cirruslabs/cirrus-ci-web/issues/439.