### PR TITLE
Fix Cirrus Terminal hangup due to invalid timeout value

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -117,9 +117,9 @@ func (ts *TerminalServer) Run(ctx context.Context) (err error) {
 
 	startServer := func(listener net.Listener) error {
 		server := http.Server{
-			Handler:     http.HandlerFunc(grpcHandler),
-			ReadTimeout: 5 * time.Second,
-			TLSConfig:   ts.tlsConfig,
+			Handler:           http.HandlerFunc(grpcHandler),
+			ReadHeaderTimeout: 5 * time.Second,
+			TLSConfig:         ts.tlsConfig,
 		}
 
 		ts.logger.Sugar().Infof("starting server on %s...", listener.Addr().String())


### PR DESCRIPTION
It's OK for WebSockets to not send any data for a while, let's only check for the headers to be sent in a timely manner.

This regression was introduced in https://github.com/cirruslabs/terminal/pull/29.

See https://github.com/cirruslabs/cirrus-ci-web/issues/538.