### PR TITLE
Ditch gocertifi by upgrading to the latest cirrus-ci-agent version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,6 @@ linters:
     - asciicheck
     - bodyclose
     - deadcode
-    - depguard
     - dupl
     - errcheck
     - exhaustive
@@ -118,6 +117,9 @@ linters:
 
     # Unfortunately too much false-positives, e.g. for a 0700 umask or number 10 when using strconv.FormatInt()
     - gomnd
+
+    # Needs package whitelists
+    - depguard
 
 issues:
   # Don't hide multiple issues that belong to one class since GitHub annotations can handle them all nicely.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	cloud.google.com/go/compute/metadata v0.2.3
 	github.com/blendle/zapdriver v1.3.1
-	github.com/cirruslabs/cirrus-ci-agent v1.101.0
+	github.com/cirruslabs/cirrus-ci-agent v1.112.0
 	github.com/creack/pty v1.1.18
 	github.com/google/uuid v1.3.0
 	github.com/improbable-eng/grpc-web v0.15.0
@@ -20,7 +20,6 @@ require (
 require (
 	cloud.google.com/go/compute v1.18.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
-	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,11 +39,9 @@ github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInq
 github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
 github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d h1:S2NE3iHSwP0XV47EEXL8mWmRdEfGscSJ+7EgePNgt0s=
-github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cirruslabs/cirrus-ci-agent v1.101.0 h1:mkQqVYioUZ1DFak+BvAVKVPZ+HZo7WKM7Nip6b6/tAw=
-github.com/cirruslabs/cirrus-ci-agent v1.101.0/go.mod h1:5yBp+i8c3bth49CRIQxaFvKo8G4TR6x5qaOKI+gl49M=
+github.com/cirruslabs/cirrus-ci-agent v1.112.0 h1:zKhx+oDQ26kxBN3FxeQi4ngJTB6YxgDXV8hzJgbcbBI=
+github.com/cirruslabs/cirrus-ci-agent v1.112.0/go.mod h1:E/MO5/FR+uveRY4Afgx4dl6TQwmZ8wz+fNV0YuaAwHs=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -218,7 +216,7 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
+github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=


### PR DESCRIPTION
I don't think we need `x509.SetFallbackRoots()` since Cirrus Terminal server runs in an `alpine:latest` container, and Cirrus Terminal host is a Cirrus CI Agent, which already has `x509.SetFallbackRoots()` in its entrypoint.