### PR TITLE
Switch to Buf for Protocol Buffers/gRPC code-generation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,23 +10,21 @@ task:
   name: JavaScript Protocol Buffers and gRPC code-generation
   container:
     image: node:latest
-  env:
-    OUTDIR: js-codegen
   prepare_script:
     - apt-get update && apt-get -y install protobuf-compiler
-    - npm install ts-protoc-gen
-  code_generation_script:
-    - mkdir $OUTDIR
-    - >
-      protoc
-      --plugin="protoc-gen-ts=node_modules/.bin/protoc-gen-ts"
-      --js_out="import_style=commonjs,binary:$OUTDIR"
-      --ts_out="service=grpc-web:$OUTDIR"
-      -I proto/
-      proto/terminal.proto
-    - find $OUTDIR
-  js_proto_codegen_artifacts:
-    path: $OUTDIR/*
+    - npm install -g @bufbuild/buf ts-protoc-gen
+    # Work around https://github.com/protocolbuffers/protobuf-javascript/issues/127,
+    - npm install -g protoc-gen-js
+  # Work around https://github.com/protocolbuffers/protobuf-javascript/issues/127,
+  # once Protocol Buffers team manages to properly release protoc-gen-js on NPM,
+  # it would be as simple as "npm install -g protoc-gen-js"
+  # (currently it's a third-party package)
+  work_around_js_split_script:
+    - wget -O - https://github.com/protocolbuffers/protobuf-javascript/releases/download/v3.21.2/protobuf-javascript-3.21.2-linux-x86_64.tar.gz | tar xz bin/protoc-gen-js
+    - mv bin/protoc-gen-js /usr/local/bin/
+  code_generation_script: buf generate
+  buf_codegen_artifacts:
+    path: buf-codegen/*
 
 docker_builder:
   name: Release Docker Image

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Buf
+buf-codegen/

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,0 +1,10 @@
+version: v1
+plugins:
+  - name: js
+    out: buf-codegen
+    opt:
+      - import_style=commonjs,binary
+  - name: ts
+    out: buf-codegen
+    opt:
+      - service=grpc-web

--- a/buf.work.yaml
+++ b/buf.work.yaml
@@ -1,0 +1,3 @@
+version: v1
+directories:
+  - proto

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,7 @@
+version: v1
+breaking:
+  use:
+    - FILE
+lint:
+  use:
+    - DEFAULT


### PR DESCRIPTION
Also works around https://github.com/protocolbuffers/protobuf-javascript/issues/127 causing the build to fail on `main`.

Resolves #34.